### PR TITLE
Filter added in to show/hide the display name dropdown

### DIFF
--- a/force-first-last.php
+++ b/force-first-last.php
@@ -17,13 +17,17 @@ Author URI: http://www.strangerstudios.com
 */
 function ffl_show_user_profile($user)
 {
-?>
-<script>
-	jQuery(document).ready(function() {
-		jQuery('#display_name').parent().parent().hide();
-	});
-</script>
-<?php
+	$hide_display_name = apply_filters( 'pmpro_ffl_hide_display_name_profile', true, $user );
+
+	if( $hide_display_name ){
+		?>
+		<script>
+			jQuery(document).ready(function() {
+				jQuery('#display_name').parent().parent().hide();
+			});
+		</script>
+		<?php
+	}
 }
 add_action( 'show_user_profile', 'ffl_show_user_profile' );
 add_action( 'edit_user_profile', 'ffl_show_user_profile' );


### PR DESCRIPTION
There's a bit of a delay before the JS kicks in and hides the field. Might be causing some confusion from what I can see from this issue https://github.com/strangerstudios/pmpro-add-name-to-checkout/issues/17

Disable the JS using this:

`add_filter( 'pmpro_ffl_hide_display_name_profile', '__return_false' );`